### PR TITLE
Creación campo Nombre en contenido Cliente

### DIFF
--- a/config/sync/core.entity_form_display.node.cliente.default.yml
+++ b/config/sync/core.entity_form_display.node.cliente.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.cliente.body
+    - field.field.node.cliente.field_cliente_nombre
     - node.type.cliente
   module:
     - path
@@ -29,6 +30,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_cliente_nombre:
+    weight: 122
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
     weight: 2

--- a/config/sync/core.entity_view_display.node.cliente.default.yml
+++ b/config/sync/core.entity_view_display.node.cliente.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.cliente.body
+    - field.field.node.cliente.field_cliente_nombre
     - node.type.cliente
   module:
     - text
@@ -19,6 +20,14 @@ content:
     weight: 101
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_cliente_nombre:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   links:
     weight: 100

--- a/config/sync/core.entity_view_display.node.cliente.teaser.yml
+++ b/config/sync/core.entity_view_display.node.cliente.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.cliente.body
+    - field.field.node.cliente.field_cliente_nombre
     - node.type.cliente
   module:
     - text
@@ -28,4 +29,5 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_cliente_nombre: true
   langcode: true

--- a/config/sync/field.field.node.cliente.field_cliente_nombre.yml
+++ b/config/sync/field.field.node.cliente.field_cliente_nombre.yml
@@ -1,0 +1,27 @@
+uuid: 65a55357-51e2-4f26-81d8-7d66c8b92d60
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cliente_nombre
+    - node.type.cliente
+  module:
+    - unique_field_ajax
+third_party_settings:
+  unique_field_ajax:
+    unique: 0
+    per_lang: 0
+    use_ajax: 0
+    message: ''
+id: node.cliente.field_cliente_nombre
+field_name: field_cliente_nombre
+entity_type: node
+bundle: cliente
+label: Nombre
+description: 'Digitar el nombre del cliente.  Ej:  Carlos'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_cliente_nombre.yml
+++ b/config/sync/field.storage.node.field_cliente_nombre.yml
@@ -1,0 +1,25 @@
+uuid: 4eef0668-be55-4e87-b805-63bdd40261c4
+langcode: es
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_cliente_nombre
+field_name: field_cliente_nombre
+entity_type: node
+type: string
+settings:
+  max_length: 50
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Ajustes realizados

### Historia de Usuario Realizada
- 65 - EP01-FE04-HU022 - Crear el campo Nombre en tipo de contenido Cliente
   https://dev.azure.com/mackpipe79/Mi%20Fruver/_workitems/edit/65


### Actividad
- Se creo el campo **Nombre** en el tipo de contenido **Cliente**

   ![image](https://user-images.githubusercontent.com/84405166/122265511-74859c00-ce9e-11eb-8be3-a9cc582eb889.png)

- Se incluye los archivos de configuración necesarios
