### PR TITLE
:wrench: AB#66 Se crea el campo Apellido en el tipo de contenido cliente

### DIFF
--- a/config/sync/auto_entitylabel.settings.node.cliente.yml
+++ b/config/sync/auto_entitylabel.settings.node.cliente.yml
@@ -1,0 +1,9 @@
+status: 0
+pattern: ''
+escape: false
+preserve_titles: false
+save: 0
+chunk: '50'
+dependencies:
+  config:
+    - node.type.cliente

--- a/config/sync/field.field.node.cliente.field_cliente_apellido.yml
+++ b/config/sync/field.field.node.cliente.field_cliente_apellido.yml
@@ -1,0 +1,27 @@
+uuid: 20c4ca81-6b51-4d80-bf32-3b9197472fbc
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cliente_apellido
+    - node.type.cliente
+  module:
+    - unique_field_ajax
+third_party_settings:
+  unique_field_ajax:
+    unique: 0
+    per_lang: 0
+    use_ajax: 0
+    message: ''
+id: node.cliente.field_cliente_apellido
+field_name: field_cliente_apellido
+entity_type: node
+bundle: cliente
+label: Apellido
+description: 'Ingrese su apellido Ejemplo: Chavez'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_cliente_apellido.yml
+++ b/config/sync/field.storage.node.field_cliente_apellido.yml
@@ -1,0 +1,25 @@
+uuid: 8da72a68-b0f9-478b-ad1e-b03e4186df00
+langcode: es
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_cliente_apellido
+field_name: field_cliente_apellido
+entity_type: node
+type: string
+settings:
+  max_length: 50
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## ACTIVIDAD REALIZADA

66-EP01-FE04-HU023- Crear campo Apellido en tipo de contenido Cliente
https://dev.azure.com/mackpipe79/Mi%20Fruver/_workitems/edit/66

- Se crea campo Apellido en el tipo de contenido Cliente

![image](https://user-images.githubusercontent.com/84990344/122299877-297e7f80-cec4-11eb-955e-11438b740de3.png)

- Se suben los archivos 

![image](https://user-images.githubusercontent.com/84990344/122299995-5468d380-cec4-11eb-828f-23cdf64e50d3.png)