### PR TITLE
Crear el campo Tipo Cliente en el tipo de contenido Cliente

### DIFF
--- a/config/sync/core.entity_form_display.node.cliente.default.yml
+++ b/config/sync/core.entity_form_display.node.cliente.default.yml
@@ -9,9 +9,11 @@ dependencies:
     - field.field.node.cliente.field_cliente_direccion
     - field.field.node.cliente.field_cliente_nombre
     - field.field.node.cliente.field_cliente_numero_documento
+    - field.field.node.cliente.field_cliente_tipo_cliente
     - field.field.node.cliente.field_cliente_tipo_documento
     - node.type.cliente
   module:
+    - cshs
     - path
     - telephone
     - text
@@ -74,6 +76,19 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_cliente_tipo_cliente:
+    weight: 30
+    settings:
+      parent: '0'
+      level_labels: ''
+      force_deepest: false
+      save_lineage: false
+      hierarchy_depth: 0
+      required_depth: 0
+      none_label: '- Please select -'
+    third_party_settings: {  }
+    type: cshs
     region: content
   field_cliente_tipo_documento:
     weight: 26

--- a/config/sync/core.entity_view_display.node.cliente.default.yml
+++ b/config/sync/core.entity_view_display.node.cliente.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.cliente.field_cliente_direccion
     - field.field.node.cliente.field_cliente_nombre
     - field.field.node.cliente.field_cliente_numero_documento
+    - field.field.node.cliente.field_cliente_tipo_cliente
     - field.field.node.cliente.field_cliente_tipo_documento
     - node.type.cliente
   module:
@@ -72,6 +73,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_cliente_tipo_cliente:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_cliente_tipo_documento:
     weight: 4

--- a/config/sync/core.entity_view_display.node.cliente.teaser.yml
+++ b/config/sync/core.entity_view_display.node.cliente.teaser.yml
@@ -6,9 +6,11 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.cliente.body
     - field.field.node.cliente.field_cliente_apellido
+    - field.field.node.cliente.field_cliente_celular
     - field.field.node.cliente.field_cliente_direccion
     - field.field.node.cliente.field_cliente_nombre
     - field.field.node.cliente.field_cliente_numero_documento
+    - field.field.node.cliente.field_cliente_tipo_cliente
     - field.field.node.cliente.field_cliente_tipo_documento
     - node.type.cliente
   module:
@@ -34,8 +36,10 @@ content:
     region: content
 hidden:
   field_cliente_apellido: true
+  field_cliente_celular: true
   field_cliente_direccion: true
   field_cliente_nombre: true
   field_cliente_numero_documento: true
+  field_cliente_tipo_cliente: true
   field_cliente_tipo_documento: true
   langcode: true

--- a/config/sync/field.field.node.cliente.field_cliente_tipo_cliente.yml
+++ b/config/sync/field.field.node.cliente.field_cliente_tipo_cliente.yml
@@ -1,0 +1,37 @@
+uuid: 7e394d16-a5e5-4fdf-a793-86f0be0f7908
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cliente_tipo_cliente
+    - node.type.cliente
+    - taxonomy.vocabulary.tipo_cliente
+  module:
+    - unique_field_ajax
+third_party_settings:
+  unique_field_ajax:
+    unique: 0
+    per_lang: 0
+    use_ajax: 0
+    message: ''
+id: node.cliente.field_cliente_tipo_cliente
+field_name: field_cliente_tipo_cliente
+entity_type: node
+bundle: cliente
+label: 'Tipo Cliente'
+description: 'Muestra los tipos de clientes que maneja Mi Fruver'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tipo_cliente: tipo_cliente
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_cliente_tipo_cliente.yml
+++ b/config/sync/field.storage.node.field_cliente_tipo_cliente.yml
@@ -1,0 +1,24 @@
+uuid: 4905e5d8-8d76-465f-bd27-d98681555f49
+langcode: es
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_cliente_tipo_cliente
+field_name: field_cliente_tipo_cliente
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Ajustes realizados

### Historia de Usuario Realizada
- 73 - EP01-FE04-HU030 - Crear el campo Tipo Cliente en el tipo de contenido Cliente
   https://dev.azure.com/mackpipe79/Mi%20Fruver/_workitems/edit/73


### Actividad
- Se creo el campo **Tipo Cliente** en el tipo de contenido **Cliente**

  ![image](https://user-images.githubusercontent.com/84405166/123339530-6116a880-d510-11eb-8b42-a67c60f33eb7.png)

- Se incluye los archivos de configuración necesarios
   
  ![image](https://user-images.githubusercontent.com/84405166/123339707-acc95200-d510-11eb-99f2-345f00b41164.png)
