### PR TITLE
Se elimina el termino *Bono* de la taxonomia Forma Pago

### DIFF
--- a/config/sync/structure_sync.data.yml
+++ b/config/sync/structure_sync.data.yml
@@ -2,17 +2,7 @@ taxonomies:
   forma_pago:
     -
       vid: forma_pago
-      tid: '7'
-      langcode: es
-      name: Bono
-      description__value: "<p>Los&nbsp;<strong>bonos</strong>&nbsp;son valores de deuda utilizados tanto por entidades privadas como por entidades de gobierno.</p>\r\n"
-      description__format: basic_html
-      weight: '0'
-      parent: '0'
-      uuid: e18b1df3-6f4d-48a2-ab30-6ec701f0403a
-    -
-      vid: forma_pago
-      tid: '6'
+      tid: '3'
       langcode: es
       name: Credito
       description__value: "<p>El&nbsp;<strong>crédito</strong>&nbsp;es un préstamo de dinero que una parte otorga a otra, con el compromiso de que, en el futuro, quien lo recibe devolverá dicho préstamo en forma gradual</p>\r\n"
@@ -22,7 +12,7 @@ taxonomies:
       uuid: 04966c47-a255-49a8-8aa5-6443eb5e9198
     -
       vid: forma_pago
-      tid: '5'
+      tid: '2'
       langcode: es
       name: Debito
       description__value: "<p><strong>Débito</strong>&nbsp;se define como deuda, obligación de pagar o reintegrar una cosa</p>\r\n"
@@ -32,7 +22,7 @@ taxonomies:
       uuid: ed97a8b7-25aa-476a-b89e-d7048b3fbb68
     -
       vid: forma_pago
-      tid: '4'
+      tid: '1'
       langcode: es
       name: Efectivo
       description__value: "<p>El&nbsp;<strong>efectivo</strong>&nbsp;es un elemento de balance y forma parte del activo circulante</p>\r\n"
@@ -44,7 +34,7 @@ taxonomies:
   tipo_cliente:
     -
       vid: tipo_cliente
-      tid: '2'
+      tid: '6'
       langcode: es
       name: Frecuente
       description__value: "<p>Cliente que utiliza el servicio de 4 a 6 veces al mes.</p>\r\n"
@@ -54,7 +44,7 @@ taxonomies:
       uuid: 1420c157-2ff6-4082-b90e-919c7db8c866
     -
       vid: tipo_cliente
-      tid: '1'
+      tid: '5'
       langcode: es
       name: Preferencial
       description__value: "<p>Identifica al cliente que una vez al mes como minimo utiliza los servicios.</p>\r\n"
@@ -64,7 +54,7 @@ taxonomies:
       uuid: e00b9167-fa27-494f-a5c3-26f77009ddf9
     -
       vid: tipo_cliente
-      tid: '3'
+      tid: '7'
       langcode: es
       name: VIP
       description__value: "<p>Cliente que utiliza el servicio mas de 15 veces al mes.</p>\r\n"


### PR DESCRIPTION
## AJUSTES REALIZADOS

### Historia de Usuario Realizada

- 123-EP01-FE04-BG001- Eliminar el termino Bono de la taxonomía forma pago
  https://dev.azure.com/mackpipe79/Mi%20Fruver/_workitems/edit/123

### Actividad

- Se actualizan cambio en la rama main

  ![image](https://user-images.githubusercontent.com/84990344/123708021-50c43d80-d830-11eb-9f98-965e780592d2.png)

- Se crea rama EP01-FE04-BG001-123

  ![image](https://user-images.githubusercontent.com/84990344/123708108-7a7d6480-d830-11eb-9549-f73792f0abae.png)

- Se elimina el termino Bono de la taxonomía Forma Pago

  ![image](https://user-images.githubusercontent.com/84990344/123708244-b1537a80-d830-11eb-8d16-e6f3a9f8b379.png)

- Se exportan los datos

  ![image](https://user-images.githubusercontent.com/84990344/123708303-cdefb280-d830-11eb-94fc-6ce2aaa37642.png)

- Se suben cambios 

  ![image](https://user-images.githubusercontent.com/84990344/123708372-e9f35400-d830-11eb-9c75-9c7a8466155e.png)





