### PR TITLE
Se crea campo Tipo Documento en el Tipo de contenido contacto y se elimina campo body

### DIFF
--- a/config/sync/core.entity_form_display.node.cliente.default.yml
+++ b/config/sync/core.entity_form_display.node.cliente.default.yml
@@ -3,7 +3,6 @@ langcode: es
 status: true
 dependencies:
   config:
-    - field.field.node.cliente.body
     - field.field.node.cliente.field_cliente_act_economica
     - field.field.node.cliente.field_cliente_apellido
     - field.field.node.cliente.field_cliente_celular
@@ -23,22 +22,11 @@ dependencies:
     - datetime
     - path
     - telephone
-    - text
 id: node.cliente.default
 targetEntityType: node
 bundle: cliente
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 21
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 16

--- a/config/sync/core.entity_form_display.node.contacto.default.yml
+++ b/config/sync/core.entity_form_display.node.contacto.default.yml
@@ -3,28 +3,17 @@ langcode: es
 status: true
 dependencies:
   config:
-    - field.field.node.contacto.body
     - field.field.node.contacto.field_contacto_apellido
     - field.field.node.contacto.field_contacto_nombre
+    - field.field.node.contacto.field_contacto_tipo_documento
     - node.type.contacto
   module:
     - path
-    - text
 id: node.contacto.default
 targetEntityType: node
 bundle: contacto
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 121
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 10
@@ -46,6 +35,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_contacto_tipo_documento:
+    weight: 124
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_view_display.node.cliente.default.yml
+++ b/config/sync/core.entity_view_display.node.cliente.default.yml
@@ -3,7 +3,6 @@ langcode: es
 status: true
 dependencies:
   config:
-    - field.field.node.cliente.body
     - field.field.node.cliente.field_cliente_act_economica
     - field.field.node.cliente.field_cliente_apellido
     - field.field.node.cliente.field_cliente_celular
@@ -22,7 +21,6 @@ dependencies:
     - datetime
     - options
     - panelizer
-    - text
     - user
 third_party_settings:
   panelizer:
@@ -35,13 +33,6 @@ targetEntityType: node
 bundle: cliente
 mode: default
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 1
-    settings: {  }
-    third_party_settings: {  }
-    region: content
   field_cliente_act_economica:
     weight: 14
     label: above

--- a/config/sync/core.entity_view_display.node.cliente.teaser.yml
+++ b/config/sync/core.entity_view_display.node.cliente.teaser.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.cliente.body
     - field.field.node.cliente.field_cliente_act_economica
     - field.field.node.cliente.field_cliente_apellido
     - field.field.node.cliente.field_cliente_celular
@@ -20,21 +19,12 @@ dependencies:
     - field.field.node.cliente.field_cliente_tipo_persona
     - node.type.cliente
   module:
-    - text
     - user
 id: node.cliente.teaser
 targetEntityType: node
 bundle: cliente
 mode: teaser
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 101
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    region: content
   links:
     weight: 100
     settings: {  }

--- a/config/sync/core.entity_view_display.node.contacto.default.yml
+++ b/config/sync/core.entity_view_display.node.contacto.default.yml
@@ -3,11 +3,12 @@ langcode: es
 status: true
 dependencies:
   config:
-    - field.field.node.contacto.body
     - field.field.node.contacto.field_contacto_apellido
     - field.field.node.contacto.field_contacto_nombre
+    - field.field.node.contacto.field_contacto_tipo_documento
     - node.type.contacto
   module:
+    - options
     - panelizer
     - user
 third_party_settings:
@@ -29,12 +30,18 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_contacto_tipo_documento:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   links:
     weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  body: true
   field_contacto_apellido: true
   langcode: true

--- a/config/sync/field.field.node.contacto.field_contacto_tipo_documento.yml
+++ b/config/sync/field.field.node.contacto.field_contacto_tipo_documento.yml
@@ -1,0 +1,28 @@
+uuid: fe423d30-81af-47ed-820a-4cd730da7f6b
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_contacto_tipo_documento
+    - node.type.contacto
+  module:
+    - options
+    - unique_field_ajax
+third_party_settings:
+  unique_field_ajax:
+    unique: 0
+    per_lang: 0
+    use_ajax: 0
+    message: ''
+id: node.contacto.field_contacto_tipo_documento
+field_name: field_contacto_tipo_documento
+entity_type: node
+bundle: contacto
+label: 'Tipo Documento'
+description: 'Ingrese el número de documento'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_contacto_tipo_documento.yml
+++ b/config/sync/field.storage.node.field_contacto_tipo_documento.yml
@@ -1,0 +1,34 @@
+uuid: 509f666c-a3bf-4d85-b60a-fd5e2fce02d2
+langcode: es
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - options
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_contacto_tipo_documento
+field_name: field_contacto_tipo_documento
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: CC
+      label: CC
+    -
+      value: CE
+      label: CE
+    -
+      value: PASSPORT
+      label: PASSPORT
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Ajustes realizados

### Historia de Usuario Realizada
- 95 - EP01-FE04-HU039 - Crear el tipo de Documento en tipo de contenido Contacto
   https://dev.azure.com/mackpipe79/Mi%20Fruver/_workitems/edit/95

### Actividad
- Se crea el campo Tipo Documento en el Tipo de contenido contacto

![image](https://user-images.githubusercontent.com/75544836/123860706-deb12e80-d8eb-11eb-90b4-3730b6013223.png)

- Se elimina el campo Body del tipo de contenido Cliente y tipo de contenido Contacto

- Se incluye los archivos de configuración necesarios
   
![image](https://user-images.githubusercontent.com/75544836/123860908-25068d80-d8ec-11eb-87e0-74e62e2baa81.png)
